### PR TITLE
Fix vehicle graphics plotting in animation

### DIFF
--- a/Source/Plotting/PlotManager.m
+++ b/Source/Plotting/PlotManager.m
@@ -27,6 +27,12 @@ classdef PlotManager < handle
         veh2Outline
         trl2Outline
 
+        % Handles to full vehicle graphics (body and wheels)
+        veh1Graphics
+        trl1Graphics
+        veh2Graphics
+        trl2Graphics
+
 
         % Handles to initial-position markers
         veh1StartMarker
@@ -93,6 +99,18 @@ classdef PlotManager < handle
             obj.trl1Outline = plot(obj.sharedAx, NaN, NaN, 'b-', 'LineWidth', 2);
             obj.veh2Outline = plot(obj.sharedAx, NaN, NaN, 'm-', 'LineWidth', 2);
             obj.trl2Outline = plot(obj.sharedAx, NaN, NaN, 'c-', 'LineWidth', 2);
+
+            % Reset full vehicle graphic handles
+            obj.veh1Graphics = gobjects(0);
+            obj.trl1Graphics = gobjects(0);
+            obj.veh2Graphics = gobjects(0);
+            obj.trl2Graphics = gobjects(0);
+
+            % Initialize full vehicle graphic handles
+            obj.veh1Graphics = gobjects(0);
+            obj.trl1Graphics = gobjects(0);
+            obj.veh2Graphics = gobjects(0);
+            obj.trl2Graphics = gobjects(0);
         end
 
         %% Clear Plots
@@ -202,48 +220,63 @@ classdef PlotManager < handle
 
         %% Update Vehicle Outlines
         function updateVehicleOutlines(obj, dataManager, iStep, vehicleParams1, trailerParams1, vehicleParams2, trailerParams2)
-            % Update polygon outlines for each vehicle and trailer
+            % Delete previous vehicle graphics
+            if ~isempty(obj.veh1Graphics) && any(ishandle(obj.veh1Graphics))
+                delete(obj.veh1Graphics(ishandle(obj.veh1Graphics)));
+            end
+            if ~isempty(obj.trl1Graphics) && any(ishandle(obj.trl1Graphics))
+                delete(obj.trl1Graphics(ishandle(obj.trl1Graphics)));
+            end
+            if ~isempty(obj.veh2Graphics) && any(ishandle(obj.veh2Graphics))
+                delete(obj.veh2Graphics(ishandle(obj.veh2Graphics)));
+            end
+            if ~isempty(obj.trl2Graphics) && any(ishandle(obj.trl2Graphics))
+                delete(obj.trl2Graphics(ishandle(obj.trl2Graphics)));
+            end
 
+            % Reset graphics handle arrays
+            obj.veh1Graphics = gobjects(0);
+            obj.trl1Graphics = gobjects(0);
+            obj.veh2Graphics = gobjects(0);
+            obj.trl2Graphics = gobjects(0);
+
+            % Plot updated vehicles with wheels
             sa1 = rad2deg(dataManager.globalVehicle1Data.SteeringAngle(iStep));
-            corners1 = VehiclePlotter.getVehicleCorners(
+            obj.veh1Graphics = VehiclePlotter.plotVehicle(obj.sharedAx, ...
                 dataManager.globalVehicle1Data.X(iStep), ...
                 dataManager.globalVehicle1Data.Y(iStep), ...
                 dataManager.globalVehicle1Data.Theta(iStep), ...
-                vehicleParams1, true, sa1, vehicleParams1.numTiresPerAxle);
-            set(obj.veh1Outline, 'XData', [corners1(:,1); corners1(1,1)], ...
-                                     'YData', [corners1(:,2); corners1(1,2)]);
+                vehicleParams1, 'r', true, false, sa1, ...
+                vehicleParams1.numTiresPerAxle, vehicleParams1.numAxles);
 
             if ~isempty(trailerParams1)
-                cornersT1 = VehiclePlotter.getVehicleCorners(
+                obj.trl1Graphics = VehiclePlotter.plotVehicle(obj.sharedAx, ...
                     dataManager.globalTrailer1Data.X(iStep), ...
                     dataManager.globalTrailer1Data.Y(iStep), ...
                     dataManager.globalTrailer1Data.Theta(iStep), ...
-                    trailerParams1, false, 0, trailerParams1.numTiresPerAxle);
-                set(obj.trl1Outline, 'XData', [cornersT1(:,1); cornersT1(1,1)], ...
-                                         'YData', [cornersT1(:,2); cornersT1(1,2)]);
+                    trailerParams1, 'b', false, false, 0, ...
+                    trailerParams1.numTiresPerAxle, trailerParams1.numAxles);
             else
-                set(obj.trl1Outline, 'XData', NaN, 'YData', NaN);
+                obj.trl1Graphics = gobjects(0);
             end
 
             sa2 = rad2deg(dataManager.globalVehicle2Data.SteeringAngle(iStep));
-            corners2 = VehiclePlotter.getVehicleCorners(
+            obj.veh2Graphics = VehiclePlotter.plotVehicle(obj.sharedAx, ...
                 dataManager.globalVehicle2Data.X(iStep), ...
                 dataManager.globalVehicle2Data.Y(iStep), ...
                 dataManager.globalVehicle2Data.Theta(iStep), ...
-                vehicleParams2, true, sa2, vehicleParams2.numTiresPerAxle);
-            set(obj.veh2Outline, 'XData', [corners2(:,1); corners2(1,1)], ...
-                                     'YData', [corners2(:,2); corners2(1,2)]);
+                vehicleParams2, 'm', true, false, sa2, ...
+                vehicleParams2.numTiresPerAxle, vehicleParams2.numAxles);
 
             if ~isempty(trailerParams2)
-                cornersT2 = VehiclePlotter.getVehicleCorners(
+                obj.trl2Graphics = VehiclePlotter.plotVehicle(obj.sharedAx, ...
                     dataManager.globalTrailer2Data.X(iStep), ...
                     dataManager.globalTrailer2Data.Y(iStep), ...
                     dataManager.globalTrailer2Data.Theta(iStep), ...
-                    trailerParams2, false, 0, trailerParams2.numTiresPerAxle);
-                set(obj.trl2Outline, 'XData', [cornersT2(:,1); cornersT2(1,1)], ...
-                                         'YData', [cornersT2(:,2); cornersT2(1,2)]);
+                    trailerParams2, 'c', false, false, 0, ...
+                    trailerParams2.numTiresPerAxle, trailerParams2.numAxles);
             else
-                set(obj.trl2Outline, 'XData', NaN, 'YData', NaN);
+                obj.trl2Graphics = gobjects(0);
             end
         end
 

--- a/Source/Plotting/VehiclePlotter.m
+++ b/Source/Plotting/VehiclePlotter.m
@@ -126,7 +126,7 @@ classdef VehiclePlotter
         % *
         % * @return None
         % */
-        function plotVehicle(ax, x, y, theta, vehicleParams, color, isTractor, isPassengerVehicle, steeringWheelAngle, numTiresPerAxle, numAxles)
+        function h = plotVehicle(ax, x, y, theta, vehicleParams, color, isTractor, isPassengerVehicle, steeringWheelAngle, numTiresPerAxle, numAxles)
             % Extract parameters from vehicleParams
             length = vehicleParams.length;
             width = vehicleParams.width;
@@ -171,7 +171,8 @@ classdef VehiclePlotter
             translatedCornersY = rotatedCorners(2, :) + y;
 
             % Plot the vehicle body
-            plot(ax, translatedCornersX, translatedCornersY, color, 'LineWidth', 2);
+            hBody = plot(ax, translatedCornersX, translatedCornersY, color, 'LineWidth', 2);
+            h = hBody;
 
             % Compute axle positions along the length of the vehicle
             axlePositions = linspace(-length/2 + wheelHeight/2, length/2 - wheelHeight/2, numAxles);
@@ -189,55 +190,55 @@ classdef VehiclePlotter
             if isTractor
                 if numAxles == 1
                     % Tractor rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 elseif numAxles == 2
                     % Tractor rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Tractor middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 end
                 % Tractor front axle
-                VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing + wheelbase, width, wheelWidth, wheelHeight, steeringWheelAngle, 2, vehicleParams.trackWidth);
+                h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing + wheelbase, width, wheelWidth, wheelHeight, steeringWheelAngle, 2, vehicleParams.trackWidth)];
             elseif isPassengerVehicle
-                VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 % Passenger Vehicle front axle
-                VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing + wheelbase, width, wheelWidth, wheelHeight, steeringWheelAngle, 2, vehicleParams.trackWidth);
+                h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - length/2 * cos(theta), y - length/2 * sin(theta), theta, -length/2 + vehicleParams.axleSpacing + wheelbase, width, wheelWidth, wheelHeight, steeringWheelAngle, 2, vehicleParams.trackWidth)];
             else
                 if numAxles == 1
                     % Trailer rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 elseif numAxles == 2
                     % Trailer rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 elseif numAxles == 3
                     % Trailer rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 3*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 3*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 elseif numAxles == 4
                     % Trailer rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 3*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 3*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 4*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 4*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 elseif numAxles == 5
                     % Trailer rear axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 2*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 3*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 3*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 4*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 4*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                     % Trailer middle axle
-                    VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 5*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth);
+                    h = [h, VehiclePlotter.plotAxleAndWheels(ax, x - remainingLength/2 * cos(theta), y - remainingLength/2 * sin(theta), theta, -remainingLength/2 + 5*vehicleParams.axleSpacing, width, wheelWidth, wheelHeight, 0, numTiresPerAxle, vehicleParams.trackWidth)];
                 end
             end
         end
@@ -261,7 +262,7 @@ classdef VehiclePlotter
         % *
         % * @return None
         % */
-        function plotAxleAndWheels(ax, x, y, theta, axlePos, width, wheelWidth, wheelHeight, steeringWheelAngle, numTiresPerAxle, trackWidth)
+        function h = plotAxleAndWheels(ax, x, y, theta, axlePos, width, wheelWidth, wheelHeight, steeringWheelAngle, numTiresPerAxle, trackWidth)
             % Define the axle line
             axleX = [-width/2, width/2];
             axleY = [0, 0];
@@ -278,8 +279,9 @@ classdef VehiclePlotter
             rotationMatrix = [cosd(90), -sind(90); sind(90), cosd(90)];
             rotatedAxleEnds = rotationMatrix * ([axleEnds(1, :) - centerX; axleEnds(2, :) - centerY]) + [centerX; centerY];
 
-            % Plot the axle
-            plot(ax, rotatedAxleEnds(1, :), rotatedAxleEnds(2, :), 'k', 'LineWidth', 2);
+            % Plot the axle and store the handle
+            hAxle = plot(ax, rotatedAxleEnds(1, :), rotatedAxleEnds(2, :), 'k', 'LineWidth', 2);
+            wheelHandles = [];
 
             % Define the offset distance M
             M = 0.5; % Example offset distance, adjust as needed
@@ -299,7 +301,7 @@ classdef VehiclePlotter
 
             if numTiresPerAxle == 2
                 % Plot left tire with positive offset
-                VehiclePlotter.plotWheel(ax, ...
+                wheelHandles(end+1) = VehiclePlotter.plotWheel(ax, ...
                     rotatedAxleEnds(1, 1) + (((width - trackWidth) / 2) * cos(offsetAngle)), ...
                     rotatedAxleEnds(2, 1) + (((width - trackWidth) / 2) * sin(offsetAngle)), ...
                     wheelWidth, ...
@@ -308,7 +310,7 @@ classdef VehiclePlotter
                     'k');
 
                 % Plot right tire with negative offset
-                VehiclePlotter.plotWheel(ax, ...
+                wheelHandles(end+1) = VehiclePlotter.plotWheel(ax, ...
                     rotatedAxleEnds(1, 2) - (((width - trackWidth) / 2) * cos(offsetAngle)), ...
                     rotatedAxleEnds(2, 2) - (((width - trackWidth) / 2) * sin(offsetAngle)), ...
                     wheelWidth, ...
@@ -319,28 +321,28 @@ classdef VehiclePlotter
                 % Handle cases with more than 2 tires per axle if necessary
                 % For example, duplicate the above two plots or adjust as needed
                 % Example for 4 tires:
-                VehiclePlotter.plotWheel(ax, ...
+                wheelHandles(end+1) = VehiclePlotter.plotWheel(ax, ...
                     rotatedAxleEnds(1, 1) + (((width - trackWidth) / 2) * cos(offsetAngle)),...
                     rotatedAxleEnds(2, 1) + (((width - trackWidth) / 2) * sin(offsetAngle)), ...
                     wheelWidth, ...
                     wheelHeight, ...
                     theta + phi, ...
                     'k');
-                VehiclePlotter.plotWheel(ax, ...
+                wheelHandles(end+1) = VehiclePlotter.plotWheel(ax, ...
                     rotatedAxleEnds(1, 2) - (((width - trackWidth) / 2) * cos(offsetAngle)), ...
                     rotatedAxleEnds(2, 2) - (((width - trackWidth) / 2) * sin(offsetAngle)), ...
                     wheelWidth, ...
                     wheelHeight, ...
                     theta + phi, ...
                     'k');
-                VehiclePlotter.plotWheel(ax, ...
+                wheelHandles(end+1) = VehiclePlotter.plotWheel(ax, ...
                     rotatedAxleEnds(1, 1) + (((width - trackWidth) / 2) * cos(offsetAngle)) + offsetX_positive, ...
                     rotatedAxleEnds(2, 1) + (((width - trackWidth) / 2) * sin(offsetAngle)) + offsetY_positive, ...
                     wheelWidth, ...
                     wheelHeight, ...
                     theta + phi, ...
                     'k');
-                VehiclePlotter.plotWheel(ax, ...
+                wheelHandles(end+1) = VehiclePlotter.plotWheel(ax, ...
                     rotatedAxleEnds(1, 2) - (((width - trackWidth) / 2) * cos(offsetAngle)) + offsetX_negative, ...
                     rotatedAxleEnds(2, 2) - (((width - trackWidth) / 2) * sin(offsetAngle)) + offsetY_negative, ...
                     wheelWidth, ...
@@ -351,6 +353,7 @@ classdef VehiclePlotter
 
             % Set axis equal for proper visualization
             axis equal;
+            h = [hAxle, wheelHandles];
         end
 
         %/**
@@ -368,7 +371,7 @@ classdef VehiclePlotter
         % *
         % * @return None
         % */
-        function plotWheel(ax, x, y, wheelWidth, wheelHeight, theta, color)
+        function h = plotWheel(ax, x, y, wheelWidth, wheelHeight, theta, color)
             % Define a rectangle for the wheel
             wheelX = [-wheelWidth/2, wheelWidth/2, wheelWidth/2, -wheelWidth/2, -wheelWidth/2];
             wheelY = [-wheelHeight/2, -wheelHeight/2, wheelHeight/2, wheelHeight/2, -wheelHeight/2];
@@ -381,8 +384,8 @@ classdef VehiclePlotter
             translatedWheelX = rotatedWheel(1, :) + x;
             translatedWheelY = rotatedWheel(2, :) + y;
 
-            % Plot the wheel
-            fill(ax, translatedWheelX, translatedWheelY, color);
+            % Plot the wheel and return the handle for easier updates
+            h = fill(ax, translatedWheelX, translatedWheelY, color);
         end
 
         %/**


### PR DESCRIPTION
## Summary
- return handles when plotting wheels and axles
- allow `plotVehicle` to output all graphics handles
- track vehicle graphics in `PlotManager`
- redraw full vehicles each animation step
- **fix handle deletion bug when updating vehicle graphics**

## Testing
- `true`
