### PR TITLE
Fix figure handle check for pressure matrix alerts

### DIFF
--- a/Source/Vehicle Model/VehicleGUIManager.m
+++ b/Source/Vehicle Model/VehicleGUIManager.m
@@ -1868,9 +1868,13 @@ classdef VehicleGUIManager < handle
                 pressureMatrices.(panelTag) = pressures;
             else
                 % If the panel does not exist, notify the user
-                uialert(obj.figureHandle, ...
-                    sprintf('Pressure matrix for %d tires not found.', totalTires), ...
-                    'Pressure Matrix Not Found', 'Icon', 'warning');
+                if ~isempty(obj.figureHandle) && isvalid(obj.figureHandle)
+                    uialert(obj.figureHandle, ...
+                        sprintf('Pressure matrix for %d tires not found.', totalTires), ...
+                        'Pressure Matrix Not Found', 'Icon', 'warning');
+                else
+                    warning('Pressure matrix for %d tires not found.', totalTires);
+                end
                 pressureMatrices = struct(); % Return empty if no panel found
             end
         end


### PR DESCRIPTION
## Summary
- avoid uialert crash if configuration figure is missing when retrieving pressure matrices

## Testing
- `matlab -batch "results = runtests('tests'); assertSuccess(results);"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842e12f7f6883278edf5e824e5a7bea