### PR TITLE
Fix trailer contact area assignment mismatch

### DIFF
--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -1486,6 +1486,13 @@ classdef VehicleModel < handle
                         % Individual loads are provided per tire in the weight distributions
                         trailerLoadsPerTire = vertcat(simParams.trailerBoxWeightDistributions{:});
                         perTireLoadTrailer = trailerLoadsPerTire(:,4);
+                        if length(perTireLoadTrailer) ~= length(trailerTirePressures)
+                            logMessages{end+1} = sprintf(['Warning: trailerBoxWeightDistributions length (%d) ' ...
+                                'does not match number of trailer tires (%d). Using uniform distribution.'], ...
+                                length(perTireLoadTrailer), length(trailerTirePressures));
+                            perTireLoadTrailer = (trailerMass * 9.81) / length(trailerTirePressures) * ...
+                                ones(length(trailerTirePressures),1);
+                        end
                     else
                         perTireLoadTrailer = (trailerMass * 9.81) / totalTiresTrailer * ones(totalTiresTrailer,1); % N each
                     end
@@ -1836,6 +1843,13 @@ classdef VehicleModel < handle
                     if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                         perTireLoadTrailer = vertcat(simParams.trailerBoxWeightDistributions{:});
                         perTireLoadTrailer = perTireLoadTrailer(:,4); % already in Newtons
+                        if length(perTireLoadTrailer) ~= length(trailerTirePressures)
+                            logMessages{end+1} = sprintf(['Warning: trailerBoxWeightDistributions length (%d) ' ...
+                                'does not match number of trailer tires (%d). Using uniform distribution.'], ...
+                                length(perTireLoadTrailer), length(trailerTirePressures));
+                            perTireLoadTrailer = (trailerMass * 9.81) / length(trailerTirePressures) * ...
+                                ones(length(trailerTirePressures),1);
+                        end
                     else
                         perTireLoadTrailer = (trailerMass * 9.81) / totalTiresTrailer * ones(totalTiresTrailer,1); % N each
                     end
@@ -2088,7 +2102,22 @@ classdef VehicleModel < handle
                         % Load distribution is directly provided per trailer box
                         loadDistributionTrailer = vertcat(simParams.trailerBoxWeightDistributions{:});
                         % Append computed contact areas to the distribution
-                        loadDistributionTrailer(:,5) = trailerContactAreas(:);
+                        numRowsTrailer = size(loadDistributionTrailer,1);
+                        numAreasTrailer = length(trailerContactAreas);
+                        if numRowsTrailer ~= numAreasTrailer
+                            logMessages{end+1} = sprintf(['Warning: trailerContactAreas length (%d) ' ...
+                                'does not match trailerBoxWeightDistributions rows (%d). ' ...
+                                'Using averaged contact area.'], numAreasTrailer, numRowsTrailer);
+                            if numAreasTrailer > 0
+                                avgArea = mean(trailerContactAreas);
+                            else
+                                avgArea = trailerTireWidth * trailerTireHeight;
+                            end
+                            trailerContactAreasToUse = repmat(avgArea, numRowsTrailer, 1);
+                        else
+                            trailerContactAreasToUse = trailerContactAreas(:);
+                        end
+                        loadDistributionTrailer(:,5) = trailerContactAreasToUse;
 
                         % Adjust vertical loads for road roughness
                         loadDistributionTrailer(:,4) = loadDistributionTrailer(:,4) .* (1 - 0.3 * roadRoughness);
@@ -2699,6 +2728,13 @@ classdef VehicleModel < handle
                         if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                             perTireLoadTrailer = vertcat(simParams.trailerBoxWeightDistributions{:});
                             perTireLoadTrailer = perTireLoadTrailer(:,4); % in Newtons
+                            if length(perTireLoadTrailer) ~= length(trailerTirePressures)
+                                logMessages{end+1} = sprintf(['Warning: trailerBoxWeightDistributions length (%d) ' ...
+                                    'does not match number of trailer tires (%d). Using uniform distribution.'], ...
+                                    length(perTireLoadTrailer), length(trailerTirePressures));
+                                perTireLoadTrailer = (trailerMass * 9.81) / length(trailerTirePressures) * ...
+                                    ones(length(trailerTirePressures),1);
+                            end
                         else
                             perTireLoadTrailer = (trailerMass * 9.81) / totalTiresTrailer * ones(totalTiresTrailer,1); % N each
                         end


### PR DESCRIPTION
## Summary
- handle mismatched trailer contact area lengths when loading box weight distributions
- keep previous uniform distribution fallback for trailer tire loads

## Testing
- `matlab -batch "disp('hello')"` *(fails: command not found)*
- `octave --eval "disp('hello')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842ec4a97248327a99088a0067609ba