### PR TITLE
Update trailer box mass calc and logging

### DIFF
--- a/Source/GUI/DataManager.m
+++ b/Source/GUI/DataManager.m
@@ -220,9 +220,11 @@ classdef DataManager < handle
             massVal = simParams.trailerMass;
             boxMasses = [];
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
-                boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
+                boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81 + 6000, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
             end
+            totalVehicleMass = simParams.tractorMass + massVal;
+            fprintf('Total vehicle mass updated: %.2f kg\n', totalVehicleMass);
 
             trailerParams = struct(...
                 'isTractor', false, ...

--- a/Source/Simulation/SimManager.m
+++ b/Source/Simulation/SimManager.m
@@ -1105,9 +1105,10 @@ classdef SimManager < handle
             massVal = simParams.trailerMass;
             boxMasses = [];
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
-                boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
+                boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81 + 6000, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
             end
+            fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + massVal);
 
             boxNumAxles = simParams.trailerAxlesPerBox;
             numAxles    = sum(boxNumAxles);

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -632,9 +632,11 @@ classdef VehicleModel < handle
                     if b == 1
                         totalMass = 0;
                     end
-                    totalMass = totalMass + sum(weightsKg);
+                    boxMass = sum(weightsKg) + 6000;
+                    totalMass = totalMass + boxMass;
                 end
                 simParams.trailerMass = totalMass;
+                fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + totalMass);
             end
             % --- Spinner Configuration Parameters ---
             nSpinners = max(simParams.trailerNumBoxes - 1, 0);
@@ -1301,11 +1303,12 @@ classdef VehicleModel < handle
                 if simParams.includeTrailer
                     if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                         % Compute the mass of each trailer box from its load distribution
-                        boxMasses = cellfun(@(ld) sum(ld(:,4)) / 9.81, simParams.trailerBoxWeightDistributions);
+                        boxMasses = cellfun(@(ld) sum(ld(:,4)) / 9.81 + 6000, simParams.trailerBoxWeightDistributions);
                         trailerMass = sum(boxMasses);
                     else
                         trailerMass = simParams.trailerMass;
                     end
+                    fprintf('Total vehicle mass updated: %.2f kg\n', tractorMass + trailerMass);
                     trailerWheelbase = simParams.trailerWheelbase; % Defined when trailer is included
                 else
                     trailerMass = 0;


### PR DESCRIPTION
## Summary
- adjust trailer box mass calculation to add a 6000 kg constant
- log total vehicle mass whenever trailer mass is updated

## Testing
- `npm` *(fails: shows help)*

------
https://chatgpt.com/codex/tasks/task_b_68436eace7308327b0a80ccc22e4eff7